### PR TITLE
internal model matrix reparameterization for olsranef

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModelsPermutations"
 uuid = "647c4018-d7ef-4d03-a0cc-8889a722319e"
 authors = ["Phillip Alday <me@phillipalday.com> and contributors"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 BlockDiagonals = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Phillip Alday <me@phillipalday.com> and contributors"]
 version = "0.1.2"
 
 [deps]
+BlockDiagonals = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MixedModels = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -15,6 +16,7 @@ StatsModels = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
+BlockDiagonals = "0.1.18"
 MixedModels = "3.5"
 StaticArrays = "1.0"
 StatsBase = "0.33"

--- a/src/MixedModelsPermutations.jl
+++ b/src/MixedModelsPermutations.jl
@@ -7,6 +7,7 @@ using SparseArrays
 using StaticArrays
 using Statistics
 using StatsBase
+using StatsModels
 using Tables
 
 using MixedModels: MixedModelBootstrap

--- a/src/MixedModelsPermutations.jl
+++ b/src/MixedModelsPermutations.jl
@@ -1,5 +1,6 @@
 module MixedModelsPermutations
 
+using BlockDiagonals
 using LinearAlgebra
 using MixedModels # we add several methods
 using Random

--- a/src/ols.jl
+++ b/src/ols.jl
@@ -88,9 +88,8 @@ function olsranef(model::LinearMixedModel{T}, fixef_res, ::Val{:simultaneous}) w
     flatblups = Z'Z \ Z'fixef_res
     # get back to original coding
     flatblups = BlockDiagonal(code) * @view flatblups[2:end, :]
-    @show size(flatblups)
-    blups = Vector{Matrix{T}}()
 
+    blups = Vector{Matrix{T}}()
     offset = 1
     for trm in model.reterms
         chunksize = size(trm, 2)

--- a/src/ols.jl
+++ b/src/ols.jl
@@ -13,7 +13,9 @@ effects design matrix must not be singular.
 Two methods are provided:
 1. (default) OLS estimates computed for all strata (blocking variables)
    simultaneously with `method=simultaneous`. This pools the variance
-   across estimates but does not shrink the estimates.
+   across estimates but does not shrink the estimates. Note that this method
+   internal reparameterizes the random effects matrix `Z` to use effects coding
+   and only use a single intercept shared across all grouping variables.
 2. OLS estimates computed within each stratum with `method=stratum`. This
    method is equivalent for example to computing each subject-level and each
    item-level regression separately.
@@ -23,8 +25,8 @@ give the same results.
 
 !!! warning
     If the design matrix for the random effects is rank deficient (e.g., through
-    the use of `MixedModels.fulldummy` or missing cells in the data), then only
-    method will fail.
+    the use of `MixedModels.fulldummy` or missing cells in the data), then these
+    methods will fail because no shrinkage/regularization is applied.
 """
 function olsranef(model::LinearMixedModel{T}, method=:simultaneous) where {T}
     fixef_res = copy(response(model))


### PR DESCRIPTION
This doesn't quite work yet 
- [ ] ~need to remove dependency on BlockDiagonals for compatibility with MixedModels 4.0~ looks like this isn't necessary and I can't put off the dependency reduction for later
- [x] I need to document rewriting the Z indicator matrices as a single orthogonal matrix