### PR TITLE
zerocorr support for permutation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 BlockDiagonals = "0.1.18"
-MixedModels = "4"
+MixedModels = "4.2.1"
 StaticArrays = "1.0"
 StatsBase = "0.33"
 StatsModels = "0.6"

--- a/src/mixedmodelpermutation.jl
+++ b/src/mixedmodelpermutation.jl
@@ -25,7 +25,7 @@ and correlations of the random-effects terms.
 """
 struct MixedModelPermutation{T<:AbstractFloat}
     fits::Vector
-    λ::Vector{LowerTriangular{T,Matrix{T}}}
+    λ::Vector{<:Union{LowerTriangular{T,Matrix{T}},Diagonal{T,Vector{T}}}}
     inds::Vector{Vector{Int}}
     lowerbd::Vector{T}
     fcnames::NamedTuple


### PR DESCRIPTION
closes #29 

to guarantee the same compat for bootstrap, we also raise the MixedModels compat bound.